### PR TITLE
Allow email customization

### DIFF
--- a/examtool/cli/send.py
+++ b/examtool/cli/send.py
@@ -12,7 +12,19 @@ from examtool.cli.utils import hidden_target_folder_option, exam_name_option, pr
 @exam_name_option
 @hidden_target_folder_option
 @click.option("--email", help="The email address of a particular student.")
-def send(exam, target, email):
+@click.option(
+    "--subject",
+    default="{course} Exam PDF",
+    help="The email subject to use.",
+    show_default=True
+)
+@click.option(
+    "--filename",
+    default="Encrypted {course} Exam.pdf",
+    help="The PDF filename to use.",
+    show_default=True
+)
+def send(exam, target, email, subject, filename):
     """
     Email an encrypted PDF to all students taking an exam. Specify `email` to email only a particular student.
     """
@@ -20,6 +32,22 @@ def send(exam, target, email):
         target = "out/latex/" + exam
 
     course = prettify(exam.split("-")[0])
+
+    filename = filename.format(course=course)
+    subject = subject.format(course=course)
+    body = (
+        "Hello!\n\n"
+        "You have an upcoming exam taking place on exam.cs61a.org. "
+        "You should complete your exam on that website.\n\n"
+        "Course: {course}\n"
+        "Exam: {exam}\n\n"
+        "However, if you encounter technical difficulties and are unable to do so, "
+        "we have attached an encrypted PDF containing the same exam. "
+        "You can then email your exam solutions to course staff before the deadline "
+        "rather than submitting using exam.cs61a.org. "
+        "To unlock the PDF, its password will be revealed on Piazza when the exam starts.\n\n"
+        "Good luck, and remember to have fun!"
+    ).format(course=course, exam=exam)
 
     roster = []
     if email:
@@ -31,22 +59,15 @@ def send(exam, target, email):
 
     key = get_api_key(exam=exam)
 
+    print((
+        "Subject: {subject}\n"
+        "PDF filename: {filename}\n"
+        "Body: {body}\n\n"
+    ).format(body=body, filename=filename, subject=subject))
     if input("Sending email to {} people - confirm? (y/N) ".format(len(roster))).lower() != "y":
         exit(1)
 
     for email in roster:
-        body = (
-            "Hello!\n\n"
-            "You have an upcoming exam taking place on exam.cs61a.org. "
-            "You should complete your exam on that website.\n\n"
-            "However, if you encounter technical difficulties and are unable to do so, "
-            "we have attached an encrypted PDF containing the same exam. "
-            "You can then email your exam solutions to course staff before the deadline "
-            "rather than submitting using exam.cs61a.org. "
-            "To unlock the PDF, its password will be revealed on Piazza when the exam starts.\n\n"
-            "Good luck, and remember to have fun!"
-        )
-
         with open(
             os.path.join(
                 target, "exam_" + email.replace("@", "_").replace(".", "_") + ".pdf"
@@ -59,13 +80,13 @@ def send(exam, target, email):
             "personalizations": [
                 {"to": [{"email": email}], "substitutions": {}}
             ],
-            "subject": "{course} Final Exam PDF".format(course=course),
+            "subject": subject,
             "content": [{"type": "text/plain", "value": body}],
             "attachments": [
                 {
                     "content": pdf,
                     "type": "application/pdf",
-                    "filename": "Encrypted {course} Exam.pdf".format(course=course),
+                    "filename": filename,
                     "disposition": "attachment",
                 }
             ],

--- a/examtool/cli/send.py
+++ b/examtool/cli/send.py
@@ -16,13 +16,13 @@ from examtool.cli.utils import hidden_target_folder_option, exam_name_option, pr
     "--subject",
     default="{course} Exam PDF",
     help="The email subject to use.",
-    show_default=True
+    show_default=True,
 )
 @click.option(
     "--filename",
     default="Encrypted {course} Exam.pdf",
     help="The PDF filename to use.",
-    show_default=True
+    show_default=True,
 )
 def send(exam, target, email, subject, filename):
     """


### PR DESCRIPTION
Email body should have at least `exam` to prevent confusion (added `course` because why not)